### PR TITLE
調整套件名稱及簡述

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,9 +1,9 @@
 {
     "manifest_version": 2,
-    "name": "PTT-Web-Enhanced",
+    "name": "PTT Web Enhanced",
     "version": "1.7",
 
-    "description": "幫 PTT web 版增加各種方便的功能",
+    "description": "幫 PTT web 版增加各種方便的功能，例如推文顯示樓層、高亮標示點選 ID 的所有推文、標示文章作者的推文等等。",
 
     "applications": {
         "gecko": {


### PR DESCRIPTION
Chrome 商店的套件名稱和簡述不能更改，會完全抓 manifest.json 的設定值使用。

不改的話效果就只能是這樣：

![圖片](https://user-images.githubusercontent.com/531417/151260047-d086d0d1-9edf-43e8-a6ba-c178350ecf3b.png)

![圖片](https://user-images.githubusercontent.com/531417/151260059-eb7da34e-7b99-4db8-a0b5-6682bea825a6.png)
