### PR TITLE
修正下拉搜尋

### DIFF
--- a/src/article.js
+++ b/src/article.js
@@ -338,7 +338,7 @@ const pushUserMenu = function(){
             ['span',
                 {
                     'class': 'pwe-menu__trigger',
-                    tabindex: '-1',
+                    'tabindex': '-1',
                 },
                 userid,
             ]
@@ -350,25 +350,25 @@ const pushUserMenu = function(){
                 ['div', {},
                     ['a',
                         {
-                            href: `/bbs/${board}/search?q=author:${userid}`,
+                            'href': `/bbs/${board}/search?q=author:${userid}`,
                             'class': 'pwe-menu__anchor',
                         },
                         `搜尋看板內 ${userid} 的文章`,
                     ],
                     ['a',
                         {
-                            href: `/bbs/ALLPOST/search?q=author:${userid}`,
+                            'href': `/bbs/ALLPOST/search?q=author:${userid}`,
                             'class': 'pwe-menu__anchor',
                         },
                         `搜尋 ALLPOST 板 ${userid} 的文章`,
                     ],
                     ['a',
                         {
-                            href: `https://www.google.com/search?q=site%3Aptt.cc%20${userid}`,
-                            target: '_blank',
+                            'href': `https://www.google.com/search?q=${userid}+site:ptt.cc`,
+                            'target': '_blank',
                             'class': 'pwe-menu__anchor',
                         },
-                        `Google 搜尋 ${userid}`,
+                        `Google 站內搜尋 ${userid}`,
                     ],
                 ]
             ]

--- a/src/article.js
+++ b/src/article.js
@@ -338,7 +338,7 @@ const pushUserMenu = function(){
             ['span',
                 {
                     'class': 'pwe-menu__trigger',
-                    tabindex: '0',
+                    tabindex: '-1',
                 },
                 userid,
             ]

--- a/src/board.js
+++ b/src/board.js
@@ -35,25 +35,25 @@ const authorMenu = function(){
                 ['div', {},
                     ['a',
                         {
-                            href: `/bbs/${board}/search?q=author:${author}`,
+                            'href': `/bbs/${board}/search?q=author:${author}`,
                             'class': 'pwe-menu__anchor',
                         },
                         `搜尋看板內 ${author} 的文章`,
                     ],
                     ['a',
                         {
-                            href: `/bbs/ALLPOST/search?q=author:${author}`,
+                            'href': `/bbs/ALLPOST/search?q=author:${author}`,
                             'class': 'pwe-menu__anchor',
                         },
                         `搜尋 ALLPOST 板 ${author} 的文章`,
                     ],
                     ['a',
                         {
-                            href: `https://www.google.com/search?q=site%3Aptt.cc%20${author}`,
-                            target: '_blank',
+                            'href': `https://www.google.com/search?q=${author}+site:ptt.cc`,
+                            'target': '_blank',
                             'class': 'pwe-menu__anchor',
                         },
-                        `Google 搜尋 ${author}`,
+                        `Google 站內搜尋 ${author}`,
                     ],
                 ]
             ]

--- a/src/board.js
+++ b/src/board.js
@@ -23,7 +23,7 @@ const authorMenu = function(){
             ['div',
                 {
                     'class': 'pwe-menu__trigger pwe-menu__trigger--arrow',
-                    tabindex: '0',
+                    'tabindex': '-1',
                 },
                 author
             ]


### PR DESCRIPTION
原來的版本實測無法叫出下拉選單，修正問題並加上選項。

data-option-type 看起來是多餘的，直接根據 input type 判斷即可。

刪除自動修正 AUTOPOST 版連結的功能（ALLPOST 版連結目前看起來沒問題，也許是舊 PTT web 的問題？）