### PR TITLE
支援黑名單

### DIFF
--- a/src/article.css
+++ b/src/article.css
@@ -106,3 +106,12 @@
 .pwe-board {
     text-decoration: none;
 }
+
+/* 黑名單 */
+.pwe-blocked-push {
+    opacity: 0.1;
+}
+.pwe-blocked-push-richcontent {
+    opacity: 0.1;
+    display: none;
+}

--- a/src/article.js
+++ b/src/article.js
@@ -30,6 +30,8 @@ const init = async function(){
 
     if(settings.detectThread) detectThread();
 
+    if(settings.blacklistEnabled) handleBlacklist(settings.blacklist);
+
     boardNameLink();
 };
 
@@ -653,6 +655,22 @@ const boardNameLink = function(){
     anchor.classList.add('pwe-board');
     articleMetaValue.innerHTML = '';
     articleMetaValue.appendChild(anchor);
+};
+
+const handleBlacklist = function(blacklist){
+    blacklist = new Set(blacklist);
+    for (const push of $qsa('.push')) {
+        const userId = $qs('.push-userid', push).dataset.userid;
+        if (!blacklist.has(userId)) { continue; }
+        push.classList.add('pwe-blocked-push');
+
+        //標記推文內容產生的圖片或影片預覽
+        let next = push.nextElementSibling;
+        while (next && next.matches('.richcontent')) {
+            next.classList.add('pwe-blocked-push-richcontent');
+            next = next.nextElementSibling;
+        }
+    }
 };
 
 //執行並捕捉可能的錯誤輸出到 console，方便除錯

--- a/src/board.css
+++ b/src/board.css
@@ -5,3 +5,8 @@
 .author .pwe-menu__dropdown {
     left: 0;
 }
+
+/* 黑名單 */
+.pwe-blocked-article {
+    opacity: 0.1;
+}

--- a/src/board.js
+++ b/src/board.js
@@ -3,7 +3,12 @@ const init = async function(){
     if ($qs('html.pwe')) { window.location.reload(); }
     $qs('html').classList.add('pwe');
 
+    await pweSettings.ready;
+    const settings = await pweSettings.getAll();
+
     authorMenu();
+
+    if(settings.blacklistEnabled) handleBlacklist(settings.blacklist);
 };
 
 //幫作者ID加上搜尋選單
@@ -59,6 +64,15 @@ const authorMenu = function(){
             ]
         ));
     });
+};
+
+const handleBlacklist = function(blacklist){
+    blacklist = new Set(blacklist);
+    for (const item of $qsa('.r-ent')) {
+        const userId = $qs('.meta .author .pwe-menu__trigger', item).textContent;
+        if (!blacklist.has(userId)) { continue; }
+        item.classList.add('pwe-blocked-article');
+    }
 };
 
 //執行並捕捉可能的錯誤輸出到 console，方便除錯

--- a/src/options.html
+++ b/src/options.html
@@ -62,6 +62,13 @@
         自動連結討論串
       </label>
       <br>
+
+      <label>
+        <input type="checkbox" class="options" name="blacklistEnabled">
+        啟用黑名單
+      </label>
+      <button type="button" id="blacklistSettings">設定黑名單</button>
+      <br>
     </div>
 
     <footer>

--- a/src/options.js
+++ b/src/options.js
@@ -12,6 +12,9 @@ const init = async function(){
 
     //重置設定按鈕
     $qs('#resetSettings').addEventListener('click', resetSettings);
+
+    //黑名單設定按鈕
+    $qs('#blacklistSettings').addEventListener('click', blacklistSettings);
 };
 
 //載入設定
@@ -28,6 +31,15 @@ const loadSettings = async function(){
 const resetSettings = async function(){
     await pweSettings.reset();
     loadSettings();
+};
+
+const blacklistSettings = async function(){
+    const blacklistOld = await pweSettings.get('blacklist');
+    const valueOld = blacklistOld.join(' ');
+    const valueNew = prompt('請輸入欲列入黑名單的使用者 ID（以空白字元分隔）', valueOld);
+    if (valueNew === null || valueNew === valueOld) { return; }
+    const blacklistNew = Array.from(new Set(valueNew.match(/[a-zA-Z0-9]{2,}/g) || []));
+    await pweSettings.set('blacklist', blacklistNew);
 };
 
 document.addEventListener('DOMContentLoaded', init);

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -10,6 +10,8 @@ const pweSettings = (function(){
         clickToDownloadImage: false,
         navbarAutohide: true,
         detectThread: false,
+        blacklistEnabled: true,
+        blacklist: [],
     };
 
     const init = function() {


### PR DESCRIPTION
ref: #3

目前寫法還很陽春，就是把黑名單 ID 的貼文或回文設為接近全透明，並且把推文產生的多媒體預覽隱藏。

黑名單設定介面也還很陽春，有空可以再做個像選項頁面一樣的編輯器。