### PR TITLE
自動連結討論串支援使用快取

### DIFF
--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -11,6 +11,8 @@ const pweSettings = (function(){
         navbarAutohide: true,
         detectThread: false,
         detectThreadRange: 4,
+        detectThreadCacheEnabled: true,
+        detectThreadCacheExpire: 10 * 60 * 1000,
     };
 
     const init = function() {


### PR DESCRIPTION
續 #15 

增加兩個隱藏選項供設定是否啟用快取及快取過期時間。

Firefox 隱私視窗不支援 Cache API，會自動停用快取。Chromium 無痕視窗的快取會和一般視窗分開，且關閉時自動清除。