### PR TITLE
修正 *.html 後有參數時套件無作用的問題

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,6 +34,7 @@
         {
             "matches": [
                 "https://www.ptt.cc/bbs/*/index*.html",
+                "https://www.ptt.cc/bbs/*/index*.html?*",
                 "https://www.ptt.cc/bbs/*/search?*"
             ],
             "js": [
@@ -49,7 +50,10 @@
             "run_at": "document_end"
         },
         {
-            "matches": ["https://www.ptt.cc/bbs/*/M.*.html"],
+            "matches": [
+                "https://www.ptt.cc/bbs/*/M.*.html",
+                "https://www.ptt.cc/bbs/*/M.*.html?*"
+            ],
             "js": [
                 "lib/browser-polyfill.js",
                 "utils/settings.js",


### PR DESCRIPTION
Facebook 等社群網站轉貼連結時會在網址加上 ?fbcid=* 之類的參數，加入 match pattern 以免套件無法作用於帶參數的網址。